### PR TITLE
Updating docker compose command in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ See [CONTRIBUTING](https://github.com/opiproject/opi/blob/main/CONTRIBUTING.md) 
 
 ## Getting started
 
-1. Run `docker-compose up -d`
+1. Run `docker compose up -d`
 2. Open `http://localhost:3000/explore` for querying InfluxDB
 3. Open `http://localhost:9091/api/v1/query?query=dpu_bytes_read` for querying Prometheus
 


### PR DESCRIPTION
While following the "Getting Started" section of the README.md file, I faced the following issues on running this command `docker-compose up -d`

### Issue #1
ERROR: Version in "./docker-compose.yml" is unsupported. You might be seeing this error because you're using the wrong Compose file version. Either specify a supported version (e.g "2.2" or "3.3") and place your service definitions under the `services` key, or omit the `version` key and place your service definitions at the root of the file to use version 1.

After changing the version in the docker-compose.yml the following error appeared.

### Issue #2
ERROR: The Compose file './docker-compose.yml' is invalid because:
services.spdk.healthcheck value Additional properties are not allowed ('start_period' was unexpected)
services.telegraf.healthcheck value Additional properties are not allowed ('start_period' was unexpected)

I fixed both of the issues with a slight change in docker compose command. 