### PR TITLE
feat: enhance the demo with disk telemetries

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -48,6 +48,7 @@ jobs:
           curl --fail http://127.0.0.1:9091/api/v1/query?query=net_bytes_recv_total | grep net_bytes_recv_total
           curl --fail http://127.0.0.1:9091/api/v1/query?query=nginx_requests | grep nginx_requests
           curl --fail http://127.0.0.1:9091/api/v1/query?query=redfish_thermal_fans_reading_rpm | grep redfish_thermal_fans_reading_rpm
+          curl --fail http://127.0.0.1:9091/api/v1/query?query=disk_used_percent | grep disk_used_percent
 
       - name: Logs
         if: always()

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ curl -k --user spdkuser:spdkpass -X POST -H "Content-Type: application/json" -d 
 - For example <https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/syslogreceiver>
 - TODO: need more details and examples
 
-## Qery examples
+## Query examples
 
 ```text
 curl --fail http://127.0.0.1:9091/api/v1/query?query=mem_free | grep mem_free
@@ -114,6 +114,7 @@ curl --fail http://127.0.0.1:9091/api/v1/query?query=dpu_num_blocks | grep dpu_n
 curl --fail http://127.0.0.1:9091/api/v1/query?query=net_bytes_recv_total | grep net_bytes_recv_total
 curl --fail http://127.0.0.1:9091/api/v1/query?query=nginx_requests | grep nginx_requests
 curl --fail http://127.0.0.1:9091/api/v1/query?query=redfish_thermal_fans_reading_rpm | grep redfish_thermal_fans_reading_rpm
+curl --fail http://127.0.0.1:9091/api/v1/query?query=disk_used_percent | grep disk_used_percent
 ```
 
 ## Running example

--- a/config/telegraf.conf
+++ b/config/telegraf.conf
@@ -32,6 +32,9 @@
 [[inputs.net]]
   ignore_protocol_stats = false
 
+[[inputs.disk]]
+  ignore_fs = ["tmpfs", "devtmpfs", "devfs", "iso9660", "overlay", "aufs", "squashfs"]
+
 [[outputs.file]]
   files = ["stdout"]
   data_format = "influx"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,11 @@ services:
   telegraf:
     image: docker.io/library/telegraf:1.29
     volumes:
+      - /:/hostfs:ro
       - ./config/telegraf.conf:/etc/telegraf/telegraf.conf:ro
+    environment:
+      - HOST_MOUNT_PREFIX=/hostfs
+      - HOST_PROC=/hostfs/proc
     depends_on:
       - spdk
       - influxdb


### PR DESCRIPTION
Part of https://github.com/opiproject/otel/issues/5

I have added the disk telemetry. https://github.com/influxdata/telegraf/tree/master/plugins/inputs/disk

Testing data that it works
```
$ cd config                                                                           
               
 [~/Desktop/opi/otel/config]
$ telegraf --config telegraf.conf > telegraph.txt 
                            
                            
 [~/Desktop/opi/otel/config]
 $ cat telegraph.txt | grep disk
disk,device=nvme0n1p2,fstype=ext4,host=kevin-Inspiron-15-5510,mode=rw,path=/ inodes_free=27164985i,inodes_used=4030151i,inodes_used_percent=12.919164705677193,total=501809635328i,free=235259224064i,used=240984608768i,used_percent=50.60109804151729,inodes_total=31195136i 1719322320000000000
disk,device=efivarfs,fstype=efivarfs,host=kevin-Inspiron-15-5510,mode=rw,path=/sys/firmware/efi/efivars used_percent=69.72437234617055,inodes_total=0i,inodes_free=0i,inodes_used=0i,inodes_used_percent=0,total=382876i,free=114368i,used=263388i 1719322320000000000
disk,device=nvme0n1p1,fstype=vfat,host=kevin-Inspiron-15-5510,mode=rw,path=/boot/efi inodes_total=0i,inodes_free=0i,inodes_used=0i,inodes_used_percent=0,total=1124999168i,free=1060528128i,used=64471040i,used_percent=5.730763349328984 1719322320000000000
disk,device=nvme0n1p2,fstype=ext4,host=kevin-Inspiron-15-5510,mode=rw,path=/ free=235259174912i,used=240984657920i,used_percent=50.601108362280854,inodes_total=31195136i,inodes_free=27164985i,inodes_used=4030151i,inodes_used_percent=12.919164705677193,total=501809635328i 1719322330000000000
disk,device=efivarfs,fstype=efivarfs,host=kevin-Inspiron-15-5510,mode=rw,path=/sys/firmware/efi/efivars inodes_used_percent=0,total=382876i,free=114368i,used=263388i,used_percent=69.72437234617055,inodes_total=0i,inodes_free=0i,inodes_used=0i 1719322330000000000
disk,device=nvme0n1p1,fstype=vfat,host=kevin-Inspiron-15-5510,mode=rw,path=/boot/efi free=1060528128i,used=64471040i,used_percent=5.730763349328984,inodes_total=0i,inodes_free=0i,inodes_used=0i,inodes_used_percent=0,total=1124999168i 1719322330000000000
disk,device=nvme0n1p2,fstype=ext4,host=kevin-Inspiron-15-5510,mode=rw,path=/ inodes_free=27164985i,inodes_used=4030151i,inodes_used_percent=12.919164705677193,total=501809635328i,free=235259154432i,used=240984678400i,used_percent=50.601112662599014,inodes_total=31195136i 1719322340000000000
disk,device=efivarfs,fstype=efivarfs,host=kevin-Inspiron-15-5510,mode=rw,path=/sys/firmware/efi/efivars used=263388i,used_percent=69.72437234617055,inodes_total=0i,inodes_free=0i,inodes_used=0i,inodes_used_percent=0,total=382876i,free=114368i 1719322340000000000
disk,device=nvme0n1p1,fstype=vfat,host=kevin-Inspiron-15-5510,mode=rw,path=/boot/efi used=64471040i,used_percent=5.730763349328984,inodes_total=0i,inodes_free=0i,inodes_used=0i,inodes_used_percent=0,total=1124999168i,free=1060528128i 1719322340000000000

```