### PR TITLE
fix: replace bash seq with brace expansion

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
             grep "" /sys/kernel/mm/hugepages/hugepages-*/nr_hugepages && \
             /usr/local/bin/spdk_tgt -m 0x1 -s 512 --no-pci 2>&1 & \
             echo wait 5s... && sleep 5s && cd /usr/libexec/spdk/scripts && \
-            for i in $(seq 1 10); do ./rpc.py spdk_get_version && break || sleep 1; done  && \
+            for i in {1..10}; do ./rpc.py spdk_get_version && break || sleep 1; done  && \
             ./rpc.py bdev_malloc_create -b Malloc0 64 512 && \
             ./rpc.py bdev_malloc_create -b Malloc1 64 512 && \
             ./rpc.py nvmf_create_transport -t TCP -u 8192 -m 4 -c 0  && \


### PR DESCRIPTION
replace bash seq command with brace expansion, as $(seq 1 10) led to docker compose failure